### PR TITLE
Output the name of `blk_mq_alloc_request`

### DIFF
--- a/bpf/kprobe.bpf.c
+++ b/bpf/kprobe.bpf.c
@@ -78,7 +78,7 @@ int BPF_KRETPROBE(alloc, u64 req) {
   bpf_map_update_elem(&request_map, &req, &val, BPF_ANY);
 
   struct event_t event = {};
-  event.addr = PT_REGS_IP(ctx);
+  event.addr = 0;
   event.pid = bpf_get_current_pid_tgid() >> 32;
   event.ts = bpf_ktime_get_ns();
   event.cpu_id = bpf_get_smp_processor_id();

--- a/internal/dust/output.go
+++ b/internal/dust/output.go
@@ -152,6 +152,9 @@ func (o *output) getIfaceName(netnsInode, ifindex uint32) string {
 }
 
 func getOutFuncName(o *output, addr uint64) string {
+	if addr == uint64(0xffffffffffffffff) {
+		return "blk_mq_alloc_request"
+	}
 	var funcName string
 	if ksym, ok := o.addr2name.Addr2NameMap[addr]; ok {
 		funcName = ksym.name


### PR DESCRIPTION
I cannot get the address of `blk_mq_alloc_request`, so I fill the `addr` field with 0.